### PR TITLE
Add batch file for cloning repositories

### DIFF
--- a/Gml.Launcher.sln
+++ b/Gml.Launcher.sln
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "common", "common", "{09A802
 		README.md = README.md
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
+		load-repositories.bat = load-repositories.bat
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gml.Launcher", "src\Gml.Launcher\Gml.Launcher.csproj", "{F2771E71-C782-4713-862F-217694DDDFF5}"

--- a/load-repositories.bat
+++ b/load-repositories.bat
@@ -1,0 +1,5 @@
+# clone GamerVII.Notification.Avalonia
+git clone --recursive https://github.com/GamerVII-NET/GamerVII.Notification.Avalonia.git ./src/GamerVII.Notification.Avalonia
+
+# clone Gml.Client
+git clone https://github.com/GamerVII-NET/Gml.Client.git ./src/Gml.Client


### PR DESCRIPTION
A batch file called "load-repositories.bat" has been added to automate the cloning of GamerVII.Notification.Avalonia and Gml.Client repositories. Also, the batch file has been included in Gml.Launcher solution for easy access.