### PR TITLE
Add feature to remember last selected profile

### DIFF
--- a/src/Gml.Launcher/Core/Services/StorageConstants.cs
+++ b/src/Gml.Launcher/Core/Services/StorageConstants.cs
@@ -4,4 +4,5 @@ public static class StorageConstants
 {
     public const string User = "UserInfo";
     public const string Settings = "Settings";
+    public const string LastSelectedProfileName = "LastSelectedProfile";
 }

--- a/src/Gml.Launcher/ViewModels/Components/ListViewModel.cs
+++ b/src/Gml.Launcher/ViewModels/Components/ListViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using System.Linq;
+using System.Reactive.Subjects;
 using Gml.Launcher.ViewModels.Base;
 using Gml.Web.Api.Dto.Profile;
 using ReactiveUI;
@@ -9,6 +10,7 @@ namespace Gml.Launcher.ViewModels.Components;
 
 public class ListViewModel : ViewModelBase
 {
+    internal readonly Subject<ProfileReadDto?> ProfileChanged = new();
 
     public ObservableCollection<ProfileReadDto>? Profiles
     {
@@ -29,6 +31,8 @@ public class ListViewModel : ViewModelBase
         {
             this.RaiseAndSetIfChanged(ref _selectedProfile, value);
             this.RaisePropertyChanged(nameof(HasSelectedItem));
+
+            ProfileChanged.OnNext(value);
         }
     }
 


### PR DESCRIPTION
A new feature has been added to remember the last selected profile. This is done by adding a new constant in the StorageConstants class, which is used to store the name of the last selected profile. Additionally, necessary modifications have been made in the OverviewPageViewModel and ListViewModel classes to accommodate this feature.